### PR TITLE
failure in rails4.beta1

### DIFF
--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -9,7 +9,7 @@ task :traceroute => :environment do
     exclusion_regexp = %r{/rails/info/properties|^#{Rails.application.config.assets.prefix}}
 
     routes.reject! do |route|
-      path = defined?(Journey::Route) ? route.path.spec.to_s : route.path
+      path = (defined?(ActionDispatch::Journey::Route) || defined?(Journey::Route)) ? route.path.spec.to_s : route.path
       path =~ exclusion_regexp
     end
   end


### PR DESCRIPTION
I happend under failure messages in my app of rails4.beta1

$ rake traceroute
rake aborted!
no implicit conversion of Regexp into String

From rails4, ActionDispath:Journey:Route is defined.
