### PR TITLE
Use descendants of ActionController::Base instead of ApplicationController

### DIFF
--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -14,7 +14,7 @@ task :traceroute => :environment do
     end
   end
 
-  defined_action_methods = ApplicationController.descendants.map {|controller|
+  defined_action_methods = ActionController::Base.descendants.map {|controller|
     controller.action_methods.reject {|a| (a =~ /\A(_conditional)?_callback_/) || (a == '_layout_from_proc')}.map do |action|
       "#{controller.controller_path}##{action}"
     end


### PR DESCRIPTION
There are lots of Rails engines that contain controllers inheriting from `ActtionController::Base`, not only from `ApplicationController`.

So far an issue was that there were gems which routes were picked up but their controllers weren't so they would end up in the "unused_routes" group :)
