### PR TITLE
Separate errors from routed actions

### DIFF
--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -6,10 +6,16 @@ task :traceroute => :environment do
   defined_action_methods = traceroute.defined_action_methods
 
   routed_actions = traceroute.routed_actions
+  non_error_routed_actions = routed_actions.select {|ra| ra.error.nil? }
+  errors = routed_actions.map(&:error).compact
 
-  unused_routes = routed_actions - defined_action_methods
-  unreachable_action_methods = defined_action_methods - routed_actions
+  unused_routes = non_error_routed_actions.map(&:controller_action_string) - defined_action_methods
+  unreachable_action_methods = defined_action_methods - non_error_routed_actions.map(&:controller_action_string)
 
+  if errors
+    puts "Errors"
+    errors.each {|e| puts "  #{e}"}
+  end
   puts "Unused routes (#{unused_routes.count}):"
   unused_routes.each {|route| puts "  #{route}"}
   puts "Unreachable action methods (#{unreachable_action_methods.count}):"

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -6,6 +6,12 @@ class Traceroute
     end
   end
 
+  RoutedAction = Struct.new(:verb, :controller, :action, :error) do
+    def controller_action_string
+      "#{controller}##{action}"
+    end
+  end
+
   def initialize(app)
     @app = app
   end
@@ -31,9 +37,10 @@ class Traceroute
   def routed_actions
     routes.map do |r|
       if r.requirements[:controller].blank? && r.requirements[:action].blank? && (r.path == '/:controller(/:action(/:id(.:format)))')
-        %Q["#{r.path}"  This is a legacy wild controller route that's not recommended for RESTful applications.]
+        RoutedAction.new nil, nil, nil, %Q["#{r.path}"  This is a legacy wild controller route that's not recommended for RESTful applications.]
       else
-        "#{r.requirements[:controller]}##{r.requirements[:action]}"
+        verb_string = r.verb.source.match(/[A-Z]+/)[0] + " " rescue ""
+        RoutedAction.new verb_string, r.requirements[:controller], r.requirements[:action]
       end
     end
   end

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -32,6 +32,6 @@ class RoutedActionsTest < Minitest::Test
   end
 
   def test_routed_actions
-    assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.reject {|r| r.start_with? 'rails/'}.sort
+    assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.reject {|r| r.controller_action_string.start_with? 'rails/'}.map(&:controller_action_string).sort
   end
 end


### PR DESCRIPTION
This sets things up for the next feature - reporting duplicated unused routes.
