### PR TITLE
[SUGGESTION] Find unnecessary ':only' clauses

### DIFF
--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -14,4 +14,10 @@ task :traceroute => :environment do
   unused_routes.each {|route| puts "  #{route}"}
   puts "Unreachable action methods (#{unreachable_action_methods.count}):"
   unreachable_action_methods.each {|action| puts "  #{action}"}
+  if Traceroute.dsl_warnings.any?
+    puts "DSL warnings"
+    Traceroute.dsl_warnings.each do |warning|
+      puts warning
+    end
+  end
 end


### PR DESCRIPTION
@amatsuda what do you think?  If you agree, I will backfill tests.

Sample output:

```
traceroute_demo> $ ber traceroute
Unused routes (18):
  duplicates#index
  widgits#index
  widgits#create
  widgits#new
  widgits#edit
  widgits#show
  widgits#update
  widgits#update
  widgits#destroy
  products#index
  products#create
  products#new
  products#edit
  products#show
  products#update
  products#update
  products#destroy
  item#edit
Unreachable action methods (0):
DSL warnings
The :only option on the :products resource is unnecessary; it contains the default action set of [:new, :create, :index, :show, :edit, :update, :destroy]
The :only option on the :widgits resource is unnecessary; it contains the default action set of [:new, :create, :index, :show, :edit, :update, :destroy]
```
