### PR TITLE
Support ignoring routes or actions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -72,7 +72,7 @@ OMG super helpful, isn't it?
 
 Some gems out there that inject routes or actions into our app for testing. Jasmine-Rails does this. They can give you false negatives when running this in development mode. It can be useful to ignore said routes or actions.
 
-Create a `.traceroute.yaml` file in your root directory.
+Create a .traceroute.yaml (or .traceroute.yml or .traceroute) file in your root directory.
 
   # .traceroute.yaml
   ignore_unreachable_actions:

--- a/README.rdoc
+++ b/README.rdoc
@@ -68,6 +68,20 @@ Running the Rake task will print something like this for you:
 
 OMG super helpful, isn't it?
 
+== How do I tell it to ignore routes?
+
+Some gems out there that inject routes or actions into our app for testing. Jasmine-Rails does this. They can give you false negatives when running this in development mode. It can be useful to ignore said routes or actions.
+
+Create a `.traceroute.yaml` file in your root directory.
+
+  # .traceroute.yaml
+  ignore_unreachable_actions:
+  - ^jasmine_rails\/
+  ignore_unused_routes:
+  - ^users#index
+
+Both yaml headers accept a list of regexes.
+
 
 == FAQ
 

--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -15,7 +15,7 @@ task :traceroute => :environment do
   puts "Unreachable action methods (#{unreachable_action_methods.count}):"
   unreachable_action_methods.each {|action| puts "  #{action}"}
 
-  unless (unused_routes.empty? && unreachable_action_methods.empty?) || ENV['FAIL_ON_ERROR'].blank?
+  unless (unused_routes.empty? && unreachable_action_methods.empty?) || ENV['FAIL_ON_ERROR'] != "1"
     fail "Unused routes or unreachable action methods detected."
   end
 end

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -41,7 +41,11 @@ class Traceroute
 
   private
   def filenames
-    [".traceroute.yaml", ".traceroute.yml", ".traceroute"].select {|filename| File.exists? filename }
+    [".traceroute.yaml", ".traceroute.yml", ".traceroute"].select { |filename|
+      File.exists? filename
+    }.select { |filename|
+      YAML.load_file(filename)
+    }
   end
 
   def at_least_one_file_exists?
@@ -61,14 +65,18 @@ class Traceroute
     return unless at_least_one_file_exists?
 
     if ignore_config.has_key? 'ignore_unreachable_actions'
-      ignore_config['ignore_unreachable_actions'].each do |ignored_action|
-        @ingored_unreachable_actions << Regexp.new(ignored_action)
+      unless ignore_config['ignore_unreachable_actions'].nil?
+        ignore_config['ignore_unreachable_actions'].each do |ignored_action|
+          @ingored_unreachable_actions << Regexp.new(ignored_action)
+        end
       end
     end
 
     if ignore_config.has_key? 'ignore_unused_routes'
-      ignore_config['ignore_unused_routes'].each do |ignored_action|
-        @ingored_unused_routes << Regexp.new(ignored_action)
+      unless ignore_config['ignore_unused_routes'].nil?
+        ignore_config['ignore_unused_routes'].each do |ignored_action|
+          @ingored_unused_routes << Regexp.new(ignored_action)
+        end
       end
     end
   end

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -48,12 +48,16 @@ class Traceroute
 
     ignore_config = YAML.load_file(".traceroute.yaml")
 
-    ignore_config['ignore_unreachable_actions'].each do |ignored_action|
-      @ingored_unreachable_actions << Regexp.new(ignored_action)
+    if ignore_config.has_key? 'ignore_unreachable_actions'
+      ignore_config['ignore_unreachable_actions'].each do |ignored_action|
+        @ingored_unreachable_actions << Regexp.new(ignored_action)
+      end
     end
 
-    ignore_config['ignore_unused_routes'].each do |ignored_action|
-      @ingored_unused_routes << Regexp.new(ignored_action)
+    if ignore_config.has_key? 'ignore_unused_routes'
+      ignore_config['ignore_unused_routes'].each do |ignored_action|
+        @ingored_unused_routes << Regexp.new(ignored_action)
+      end
     end
   end
 

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -26,7 +26,7 @@ class Traceroute
       controller.action_methods.reject {|a| (a =~ /\A(_conditional)?_callback_/) || (a == '_layout_from_proc')}.map do |action|
         "#{controller.controller_path}##{action}"
       end
-    end.flatten.reject {|r| @ingored_unreachable_actions.any? { |m| r.match(m) } }
+    end.flatten.reject {|r| @ignored_unreachable_actions.any? { |m| r.match(m) } }
   end
 
   def routed_actions
@@ -36,7 +36,7 @@ class Traceroute
       else
         "#{r.requirements[:controller]}##{r.requirements[:action]}"
       end
-    end.flatten.reject {|r| @ingored_unused_routes.any? { |m| r.match(m) } }
+    end.flatten.reject {|r| @ignored_unused_routes.any? { |m| r.match(m) } }
   end
 
   private
@@ -59,15 +59,15 @@ class Traceroute
   end
 
   def load_ignored_regex!
-    @ingored_unreachable_actions = [/^rails\//]
-    @ingored_unused_routes = [/^rails\//]
+    @ignored_unreachable_actions = [/^rails\//]
+    @ignored_unused_routes = [/^rails\//]
 
     return unless at_least_one_file_exists?
 
     if ignore_config.has_key? 'ignore_unreachable_actions'
       unless ignore_config['ignore_unreachable_actions'].nil?
         ignore_config['ignore_unreachable_actions'].each do |ignored_action|
-          @ingored_unreachable_actions << Regexp.new(ignored_action)
+          @ignored_unreachable_actions << Regexp.new(ignored_action)
         end
       end
     end
@@ -75,7 +75,7 @@ class Traceroute
     if ignore_config.has_key? 'ignore_unused_routes'
       unless ignore_config['ignore_unused_routes'].nil?
         ignore_config['ignore_unused_routes'].each do |ignored_action|
-          @ingored_unused_routes << Regexp.new(ignored_action)
+          @ignored_unused_routes << Regexp.new(ignored_action)
         end
       end
     end

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -8,7 +8,6 @@ class Traceroute
 
   def initialize(app)
     @app = app
-    @filenames = [".traceroute.yaml", ".traceroute.yml", ".traceroute"]
     load_ignored_regex!
   end
 
@@ -41,14 +40,18 @@ class Traceroute
   end
 
   private
+  def filenames
+    [".traceroute.yaml", ".traceroute.yml", ".traceroute"]
+  end
+
   def at_least_one_file_exists?
-    exists = @filenames.map {|filename| File.exists? filename }.select {|exists| exists }
+    exists = filenames.map {|filename| File.exists? filename }.select {|exists| exists }
 
     return !exists.empty?
   end
 
   def ignore_config
-    @filenames.each do |filename|
+    filenames.each do |filename|
       next unless File.exists? filename
 
       return YAML.load_file(filename)

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -21,11 +21,16 @@ class Traceroute
   end
 
   def defined_action_methods
+    regex = [
+      /^rails\//,
+      /^jasmine_rails\//
+    ]
+
     ActionController::Base.descendants.map do |controller|
       controller.action_methods.reject {|a| (a =~ /\A(_conditional)?_callback_/) || (a == '_layout_from_proc')}.map do |action|
         "#{controller.controller_path}##{action}"
       end
-    end.flatten.reject {|r| r.start_with? 'rails/'}
+    end.flatten.reject {|r| regex.any? { |m| r.match(m) } }
   end
 
   def routed_actions

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -34,13 +34,17 @@ class Traceroute
   end
 
   def routed_actions
+    regex = [
+      /^rails\//
+    ]
+
     routes.map do |r|
       if r.requirements[:controller].blank? && r.requirements[:action].blank? && (r.path == '/:controller(/:action(/:id(.:format)))')
         %Q["#{r.path}"  This is a legacy wild controller route that's not recommended for RESTful applications.]
       else
         "#{r.requirements[:controller]}##{r.requirements[:action]}"
       end
-    end.reject {|r| r.start_with? 'rails/'}
+    end.flatten.reject {|r| regex.any? { |m| r.match(m) } }
   end
 
   private

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -8,6 +8,7 @@ class Traceroute
 
   def initialize(app)
     @app = app
+    @filenames = [".traceroute.yaml", ".traceroute.yml", ".traceroute"]
     load_ignored_regex!
   end
 
@@ -40,13 +41,25 @@ class Traceroute
   end
 
   private
+  def at_least_one_file_exists?
+    exists = @filenames.map {|filename| File.exists? filename }.select {|exists| exists }
+
+    return !exists.empty?
+  end
+
+  def ignore_config
+    @filenames.each do |filename|
+      next unless File.exists? filename
+
+      return YAML.load_file(filename)
+    end
+  end
+
   def load_ignored_regex!
     @ingored_unreachable_actions = [/^rails\//]
     @ingored_unused_routes = [/^rails\//]
 
-    return unless File.exists? ".traceroute.yaml"
-
-    ignore_config = YAML.load_file(".traceroute.yaml")
+    return unless at_least_one_file_exists?
 
     if ignore_config.has_key? 'ignore_unreachable_actions'
       ignore_config['ignore_unreachable_actions'].each do |ignored_action|

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -41,19 +41,15 @@ class Traceroute
 
   private
   def filenames
-    [".traceroute.yaml", ".traceroute.yml", ".traceroute"]
+    [".traceroute.yaml", ".traceroute.yml", ".traceroute"].select {|filename| File.exists? filename }
   end
 
   def at_least_one_file_exists?
-    exists = filenames.map {|filename| File.exists? filename }.select {|exists| exists }
-
-    return !exists.empty?
+    return !filenames.empty?
   end
 
   def ignore_config
     filenames.each do |filename|
-      next unless File.exists? filename
-
       return YAML.load_file(filename)
     end
   end

--- a/test/app.rb
+++ b/test/app.rb
@@ -24,4 +24,8 @@ module Admin; class ShopsController < ApplicationController
   def create; end
 end; end
 
+module JasmineRails; class SpecRunner < ApplicationController
+  def index; end
+end; end
+
 DummyApp::Application.initialize!

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -10,6 +10,10 @@ class TracerouteTest < Minitest::Test
     assert_equal ['users#index', 'users#index2', 'users#show', 'admin/shops#index', 'admin/shops#create'], @traceroute.defined_action_methods
   end
 
+  def test_jasmine_rails_is_ignored
+    refute @traceroute.defined_action_methods.include? 'jasmine_rails/spec_runner#index'
+  end
+
   def test_routed_actions
     assert_empty @traceroute.routed_actions
   end
@@ -24,6 +28,7 @@ class RoutedActionsTest < Minitest::Test
         resources :shops, :only => :index
       end
     end
+
     @traceroute = Traceroute.new Rails.application
   end
 

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -73,6 +73,72 @@ class DotFileTest < Minitest::Test
   end
 end
 
+class EmptyFileTest < Minitest::Test
+  def setup
+    File.open ".traceroute.yaml", "w" do |file|
+    end
+
+    DummyApp::Application.routes.draw do
+      resources :users, :only => [:index, :show, :new, :create]
+
+      namespace :admin do
+        resources :shops, :only => :index
+      end
+    end
+
+    @traceroute = Traceroute.new Rails.application
+    @traceroute.load_everything!
+  end
+
+  def teardown
+    DummyApp::Application.routes.clear!
+
+    File.delete ".traceroute.yaml"
+  end
+
+   def test_empty_yaml_file_is_handled_the_same_as_no_file
+    assert_equal ['users#index', 'users#index2', 'users#show', 'admin/shops#index', 'admin/shops#create', 'jasmine_rails/spec_runner#index'], @traceroute.defined_action_methods
+  end
+
+  def test_property_with_no_key
+    assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
+  end
+end
+
+class InvalidFileTest < Minitest::Test
+  def setup
+    File.open ".traceroute.yml", "w" do |file|
+      file.puts 'ignore_unreachable_actions:'
+      file.puts 'ignore_unused_routes:'
+    end
+
+    DummyApp::Application.routes.draw do
+      resources :users, :only => [:index, :show, :new, :create]
+
+      namespace :admin do
+        resources :shops, :only => :index
+      end
+    end
+
+    @traceroute = Traceroute.new Rails.application
+    @traceroute.load_everything!
+  end
+
+  def teardown
+    DummyApp::Application.routes.clear!
+
+    File.delete ".traceroute.yml"
+  end
+
+   def test_empty_yaml_file_is_handled_the_same_as_no_file
+    assert_equal ['users#index', 'users#index2', 'users#show', 'admin/shops#index', 'admin/shops#create', 'jasmine_rails/spec_runner#index'], @traceroute.defined_action_methods
+  end
+
+  def test_property_with_no_key
+    assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
+  end
+end
+
 class FilenameSupportTest < Minitest::Test
   def test_yml_supported
     File.open ".traceroute.yml", "w" do |file|

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -73,6 +73,40 @@ class DotFileTest < Minitest::Test
   end
 end
 
+class FilenameSupportTest < Minitest::Test
+  def test_yml_supported
+    File.open ".traceroute.yml", "w" do |file|
+      file.puts 'ignore_unreachable_actions:'
+      file.puts '- ^jasmine_rails\/'
+      file.puts 'ignore_unused_routes:'
+      file.puts '- ^users'
+    end
+
+    @traceroute = Traceroute.new Rails.application
+    @traceroute.load_everything!
+
+    refute @traceroute.defined_action_methods.include? 'jasmine_rails/spec_runner#index'
+
+    File.delete ".traceroute.yml"
+  end
+
+  def test_no_extension_supported
+    File.open ".traceroute", "w" do |file|
+      file.puts 'ignore_unreachable_actions:'
+      file.puts '- ^jasmine_rails\/'
+      file.puts 'ignore_unused_routes:'
+      file.puts '- ^users'
+    end
+
+    @traceroute = Traceroute.new Rails.application
+    @traceroute.load_everything!
+
+    refute @traceroute.defined_action_methods.include? 'jasmine_rails/spec_runner#index'
+
+    File.delete ".traceroute"
+  end
+end
+
 class TracerouteRakeTests < Minitest::Test
   def setup
     require 'rake'

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -47,11 +47,11 @@ class TracerouteRakeTests < Minitest::Test
     load "./lib/tasks/traceroute.rake"
   end
 
-  def test_dont_fail_when_envvar_not_set
+  def test_dont_fail_when_envvar_is_anything_but_1
     traceroute = Traceroute.new Rails.application
     traceroute.load_everything!
 
-    ENV['FAIL_ON_ERROR'] = ""
+    ENV['FAIL_ON_ERROR'] = "DERP"
     Rake::Task[:traceroute].execute
   end
 


### PR DESCRIPTION
Added support for a .traceroute, .traceroute.yml or .traceroute.yaml file. If it's found in the root directory then it'll read the file in and add the ignore regexes to the array of routes/actions to ignore.

I've added some doco to the readme. Tests are included.
