### PR TITLE
Take into account ActionController::API descendants

### DIFF
--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -27,10 +27,12 @@ class Traceroute
   end
 
   def defined_action_methods
-    ActionController::Base.descendants.map do |controller|
-      controller.action_methods.reject {|a| (a =~ /\A(_conditional)?_callback_/) || (a == '_layout_from_proc')}.map do |action|
-        "#{controller.controller_path}##{action}"
-      end
+    [ActionController::Base, ActionController::API].map do |klass|
+      klass.descendants.map do |controller|
+        controller.action_methods.reject {|a| (a =~ /\A(_conditional)?_callback_/) || (a == '_layout_from_proc')}.map do |action|
+          "#{controller.controller_path}##{action}"
+        end
+      end.flatten
     end.flatten.reject {|r| @ignored_unreachable_actions.any? { |m| r.match(m) } }
   end
 

--- a/test/app.rb
+++ b/test/app.rb
@@ -14,6 +14,7 @@ module DummyApp
 end
 
 class ApplicationController < ActionController::Base; end
+class ApiController < ActionController::API; end
 
 class UsersController < ApplicationController
   def index; end
@@ -22,6 +23,11 @@ class UsersController < ApplicationController
 end
 
 module Admin; class ShopsController < ApplicationController
+  def index; end
+  def create; end
+end; end
+
+module Api; class BooksController < ApiController
   def index; end
   def create; end
 end; end

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -9,7 +9,7 @@ module TracerouteTest
     end
 
     def test_defined_action_methods
-      assert_equal ['users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index'].sort, @traceroute.defined_action_methods.sort
+      assert_equal ['users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index'].sort, @traceroute.defined_action_methods.sort
     end
 
     def test_routed_actions
@@ -25,6 +25,10 @@ module TracerouteTest
         namespace :admin do
           resources :shops, :only => :index
         end
+
+        namespace :api do
+          resources :books, :only => :index
+        end
       end
 
       @traceroute = Traceroute.new Rails.application
@@ -35,7 +39,7 @@ module TracerouteTest
     end
 
     def test_routed_actions
-      assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
+      assert_equal ['admin/shops#index', 'api/books#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
     end
   end
 
@@ -74,6 +78,10 @@ module TracerouteTest
 
         namespace :admin do
           resources :shops, :only => [:index, :create]
+        end
+
+        namespace :api do
+          resources :books, :only => [:index, :create]
         end
 
         namespace :rails do

--- a/test/traceroute_with_engine_test.rb
+++ b/test/traceroute_with_engine_test.rb
@@ -32,7 +32,7 @@ module TracerouteWithEngineTest
     end
 
     def test_defined_action_methods
-      assert_equal ["admin/shops#create", "admin/shops#index", "test_engine/tasks#index", "users#index", "users#index2", "users#show"].sort, @traceroute.defined_action_methods.sort
+      assert_equal ["admin/shops#create", "admin/shops#index", "api/books#create", "api/books#index", "test_engine/tasks#index", "users#index", "users#index2", "users#show"].sort, @traceroute.defined_action_methods.sort
     end
 
     def test_routed_actions
@@ -83,7 +83,7 @@ module TracerouteWithEngineTest
     end
 
     def test_defined_action_methods
-      assert_equal ["admin/shops#create", "admin/shops#index", "test_engine/tasks#index", "users#index", "users#index2", "users#show"].sort, @traceroute.defined_action_methods.sort
+      assert_equal ["admin/shops#create", "admin/shops#index", "api/books#create", "api/books#index", "test_engine/tasks#index", "users#index", "users#index2", "users#show"].sort, @traceroute.defined_action_methods.sort
     end
 
     def test_routed_actions

--- a/test/yaml_test.rb
+++ b/test/yaml_test.rb
@@ -36,6 +36,10 @@ class DotFileTest < Minitest::Test
       namespace :admin do
         resources :shops, :only => :index
       end
+
+      namespace :api do
+        resources :books, :only => :index
+      end
     end
 
     @traceroute = Traceroute.new Rails.application
@@ -52,7 +56,7 @@ class DotFileTest < Minitest::Test
   end
 
   def test_used_routes_are_ignored
-    assert_equal ['admin/shops#index'].sort, @traceroute.routed_actions.sort
+    assert_equal ['admin/shops#index', 'api/books#index'].sort, @traceroute.routed_actions.sort
   end
 end
 
@@ -69,6 +73,9 @@ class EmptyFileTest < Minitest::Test
       namespace :admin do
         resources :shops, :only => :index
       end
+      namespace :api do
+        resources :books, :only => :index
+      end
     end
 
     @traceroute = Traceroute.new Rails.application
@@ -81,11 +88,11 @@ class EmptyFileTest < Minitest::Test
   end
 
   def test_empty_yaml_file_is_handled_the_same_as_no_file
-    assert_equal ['users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'jasmine_rails/spec_runner#index'].sort, @traceroute.defined_action_methods.sort
+    assert_equal ['users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'jasmine_rails/spec_runner#index'].sort, @traceroute.defined_action_methods.sort
   end
 
   def test_property_with_no_key
-    assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
+    assert_equal ['admin/shops#index', 'api/books#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
   end
 end
 
@@ -104,6 +111,10 @@ class InvalidFileTest < Minitest::Test
       namespace :admin do
         resources :shops, :only => :index
       end
+
+      namespace :api do
+        resources :books, :only => :index
+      end
     end
 
     @traceroute = Traceroute.new Rails.application
@@ -116,11 +127,11 @@ class InvalidFileTest < Minitest::Test
   end
 
   def test_empty_yaml_file_is_handled_the_same_as_no_file
-    assert_equal ['users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'jasmine_rails/spec_runner#index'].sort, @traceroute.defined_action_methods.sort
+    assert_equal ['users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'jasmine_rails/spec_runner#index'].sort, @traceroute.defined_action_methods.sort
   end
 
   def test_property_with_no_key
-    assert_equal ['admin/shops#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
+    assert_equal ['admin/shops#index', 'api/books#index', 'users#index', 'users#show', 'users#new', 'users#create'].sort, @traceroute.routed_actions.sort
   end
 end
 


### PR DESCRIPTION
ActionController::API isn't a descendent of ActionController::Base . To take into account all controllers derived from ActionController::API, I added a loop in defined_action_methods.

To test it, I added an _api_ namespace. It was written to mimic _admin_ namespace.