### PR TITLE
Fix for Rails 6: Zeitwerk class loading (Fix #36)

### DIFF
--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -39,6 +39,8 @@ class Traceroute
     ::Rails::MailersController rescue NameError
     @app.reload_routes!
 
+    Zeitwerk::Loader.eager_load_all if Object.const_defined?("Zeitwerk")
+
     Rails::Engine.subclasses.each(&:eager_load!)
   end
 


### PR DESCRIPTION
There are reports on this gem not working in Rails 6.

I looked into this & it seems like controllers aren't loaded with `@all.eager_load!` because of the new class autoloader, [Zeitwerk](https://github.com/fxn/zeitwerk/).

[This code](https://github.com/rails/rails/blob/439d4995c1dab475b576fcb19ea95ae37e0ed222/railties/lib/rails/engine.rb#L473), from Rails 6 `eager_load!`, shows that if Zeitwerk is enabled (default in Rails 6), then it returns & does nothing.

Calling `Zeitwerk::Loader.eager_load_all` fixes that.
