### PR TITLE
overridden-routes-checker

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,7 @@ Consider you have the following routes.rb and a controller:
   # config/routes.rb
   YourRailsApp::Application.routes.draw do
     resources :users, :only => [:index, :show, :new, :create]
+    get "/users/custom_action", :to => "users#custom_action"
     match 'products/:id/purchase' => 'catalog#purchase', :as => :purchase
   end
 
@@ -50,6 +51,9 @@ Consider you have the following routes.rb and a controller:
     end
 
     def index2
+    end
+
+    def custom_action
     end
 
     def show
@@ -63,8 +67,13 @@ Running the Rake task will print something like this for you:
     users#create
     users#new
     catalog#purchase
+
   Unreachable action methods (1):
     users#index2
+
+  Overridden routes (1 group):
+    GET /users/:id(.:format) users#show
+      GET /users/custom_action(.:format) users#custom_action
 
 OMG super helpful, isn't it?
 
@@ -79,6 +88,8 @@ Create a .traceroute.yaml (or .traceroute.yml or .traceroute) file in your root 
   - ^jasmine_rails\/
   ignore_unused_routes:
   - ^users#index
+  ignore_overridden_routes:
+  - ^/users/custom_action
 
 Both yaml headers accept a list of regexes.
 

--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -5,22 +5,44 @@ task :traceroute => :environment do
   traceroute = Traceroute.new Rails.application
   traceroute.load_everything!
 
-  unless ENV['UNREACHABLE_ACTION_METHODS_ONLY']
+  check_unused_routes = !ENV['UNREACHABLE_ACTION_METHODS_ONLY'] && !ENV['OVERRIDDEN_ROUTES_ONLY']
+  check_unreachable_action_methods = !ENV['UNUSED_ROUTES_ONLY'] && !ENV['OVERRIDDEN_ROUTES_ONLY']
+  check_overridden_routes = !ENV['UNREACHABLE_ACTION_METHODS_ONLY'] && !ENV['UNUSED_ROUTES_ONLY']
+  failed_checks = []
+
+  if check_unused_routes
     unused_routes = traceroute.unused_routes
+    failed_checks << :unused_routes if unused_routes.present?
+
     puts "Unused routes (#{unused_routes.count}):"
-    unused_routes.each {|route| puts "  #{route}"}
+    unused_routes.each { |route| puts "  #{route}" }
+    puts
   end
 
-  puts unless (ENV['UNREACHABLE_ACTION_METHODS_ONLY'] || ENV['UNUSED_ROUTES_ONLY'])
-
-  unless ENV['UNUSED_ROUTES_ONLY']
+  if check_unreachable_action_methods
     unreachable_action_methods = traceroute.unreachable_action_methods
+    failed_checks << :unreachable_action_methods if unreachable_action_methods.present?
+
     puts "Unreachable action methods (#{unreachable_action_methods.count}):"
-    unreachable_action_methods.each {|action| puts "  #{action}"}
+    unreachable_action_methods.each { |action| puts "  #{action}" }
+    puts
   end
 
-  if ENV['FAIL_ON_ERROR'] && ((!ENV['UNREACHABLE_ACTION_METHODS_ONLY'] && unused_routes.any?) || (!ENV['UNUSED_ROUTES_ONLY'] && unreachable_action_methods.any?))
-    fail "Unused routes or unreachable action methods detected."
+  if check_overridden_routes
+    overridden_routes = traceroute.overridden_routes
+    failed_checks << :overridden_routes if overridden_routes.present?
+
+    puts "Overridden routes (#{overridden_routes.count} #{"group".pluralize(overridden_routes.count)}):"
+    overridden_routes.each do |overriding_route, overridden_group|
+      puts "  #{overriding_route}"
+      overridden_group.each { |overridden_route| puts "    #{overridden_route}" }
+    end
+    puts
+  end
+
+  if ENV['FAIL_ON_ERROR'] && failed_checks.present?
+    error_message = "#{failed_checks.join(", ")} detected.".humanize
+    fail error_message
   end
 end
 
@@ -34,6 +56,12 @@ namespace :traceroute do
   desc 'Prints out unreachable action methods'
   task :unreachable_action_methods => :environment do
     ENV['UNREACHABLE_ACTION_METHODS_ONLY'] = '1'
+    Rake::Task[:traceroute].invoke
+  end
+
+  desc 'Prints out overridden routes'
+  task :overridden_routes => :environment do
+    ENV['OVERRIDDEN_ROUTES_ONLY'] = '1'
     Rake::Task[:traceroute].invoke
   end
 end

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -17,19 +17,11 @@ class Traceroute
 
     @ignored_unreachable_actions = []
     @ignored_unused_routes = [/^\/cable$/]
+    @ignored_overridden_routes =[]
 
     @ignored_unused_routes << %r{^#{@app.config.assets.prefix}} if @app.config.respond_to? :assets
 
-    config_filename = %w(.traceroute.yaml .traceroute.yml .traceroute).detect {|f| File.exist?(f)}
-    if config_filename && (config = YAML.load_file(config_filename))
-      (config['ignore_unreachable_actions'] || []).each do |ignored_action|
-        @ignored_unreachable_actions << Regexp.new(ignored_action)
-      end
-
-      (config['ignore_unused_routes'] || []).each do |ignored_action|
-        @ignored_unused_routes << Regexp.new(ignored_action)
-      end
-    end
+    load_configs
   end
 
   def load_everything!
@@ -48,6 +40,18 @@ class Traceroute
 
   def unreachable_action_methods
     defined_action_methods - routed_actions
+  end
+
+  def overridden_routes
+    fetched_routes = routes
+    fake_params = Hash.new(1)
+
+    fetched_routes.each_with_object(Hash.new { |h, k| h[k] = [] })
+                  .with_index(1) do |(route1, result), route1_index|
+      fetched_routes.drop(route1_index).each do |route2|
+        result[route_info(route1)] << route_info(route2) if overrides?(route1, route2, fake_params)
+      end
+    end
   end
 
   def defined_action_methods
@@ -95,5 +99,36 @@ class Traceroute
     routes.reject! {|r| r.app.is_a?(ActionDispatch::Routing::Redirect)}
 
     routes
+  end
+
+  private
+
+  def load_configs
+    config_filename = %w(.traceroute.yaml .traceroute.yml .traceroute).detect {|f| File.exist?(f)}
+    if config_filename && (config = YAML.load_file(config_filename))
+      (config['ignore_unreachable_actions'] || []).each do |ignored_unreachable_action|
+        @ignored_unreachable_actions << Regexp.new(ignored_unreachable_action)
+      end
+
+      (config['ignore_unused_routes'] || []).each do |ignored_unused_route|
+        @ignored_unused_routes << Regexp.new(ignored_unused_route)
+      end
+
+      (config['ignore_overridden_routes'] || []).each do |ignored_overridden_route|
+        @ignored_overridden_routes << Regexp.new(ignored_overridden_route)
+      end
+    end
+  end
+
+  def overrides?(route1, route2, params)
+    return if route1.verb != route2.verb
+    return if route1.requirements == route2.requirements
+
+    route1.path.match(route2.format(params)) &&
+      @ignored_overridden_routes.all? { |ignored| !route2.path.spec.to_s.match(ignored) }
+  end
+
+  def route_info(route)
+    "#{route.verb} #{route.path.spec.to_s} #{route.requirements[:controller]}##{route.requirements[:action]}"
   end
 end

--- a/test/app.rb
+++ b/test/app.rb
@@ -20,6 +20,7 @@ class UsersController < ApplicationController
   def index; end
   def index2; end
   def show; end
+  def custom_action; end
 end
 
 module Admin; class ShopsController < ApplicationController

--- a/test/traceroute_test.rb
+++ b/test/traceroute_test.rb
@@ -9,7 +9,7 @@ module TracerouteTest
     end
 
     def test_defined_action_methods
-      assert_defined_action_methods 'users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index'
+      assert_defined_action_methods 'users#index', 'users#show', 'users#index2', 'users#custom_action', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index'
     end
 
     def test_routed_actions
@@ -62,7 +62,7 @@ module TracerouteTest
       ENV['FAIL_ON_ERROR']="1"
       Rake::Task[:traceroute].execute
     rescue => e
-      assert_includes e.message, "Unused routes or unreachable action methods detected."
+      assert_includes e.message, "Unreachable action methods detected."
     end
 
     def test_rake_task_fails_when_unused_route_detected
@@ -94,7 +94,21 @@ module TracerouteTest
         ENV['FAIL_ON_ERROR'] = "1"
         Rake::Task[:traceroute].execute
       rescue => e
-        assert_includes e.message, "Unused routes or unreachable action methods detected."
+        assert_includes e.message, "Unused routes, unreachable action methods detected."
+      end
+    end
+
+    def test_rake_task_fails_when_overridden_route_detected
+      DummyApp::Application.routes.draw do
+        resources :users, :only => [:show]
+        get "/users/custom_action", :to => "users#custom_action"
+      end
+
+      begin
+        ENV['FAIL_ON_ERROR'] = "1"
+        Rake::Task[:traceroute].execute
+      rescue => e
+        assert_includes e.message, "Unreachable action methods, overridden routes detected."
       end
     end
   end

--- a/test/traceroute_with_engine_test.rb
+++ b/test/traceroute_with_engine_test.rb
@@ -32,7 +32,7 @@ module TracerouteWithEngineTest
     end
 
     def test_defined_action_methods
-      assert_defined_action_methods 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'test_engine/tasks#index', 'users#index', 'users#index2', 'users#show'
+      assert_defined_action_methods 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'test_engine/tasks#index', 'users#index', 'users#index2', 'users#custom_action', 'users#show'
     end
 
     def test_routed_actions
@@ -83,7 +83,7 @@ module TracerouteWithEngineTest
     end
 
     def test_defined_action_methods
-      assert_defined_action_methods 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'test_engine/tasks#index', 'users#index', 'users#index2', 'users#show'
+      assert_defined_action_methods 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'test_engine/tasks#index', 'users#index', 'users#index2', 'users#custom_action', 'users#show'
     end
 
     def test_routed_actions

--- a/test/yaml_test.rb
+++ b/test/yaml_test.rb
@@ -28,10 +28,13 @@ class DotFileTest < Minitest::Test
       file.puts '- ^jasmine_rails\/'
       file.puts 'ignore_unused_routes:'
       file.puts '- ^users'
+      file.puts 'ignore_overridden_routes:'
+      file.puts '- ^/users/custom_action'
     end
 
     DummyApp::Application.routes.draw do
       resources :users, :only => [:index, :show, :new, :create]
+      get "/users/custom_action", :to => "users#custom_action"
 
       namespace :admin do
         resources :shops, :only => :index
@@ -57,6 +60,10 @@ class DotFileTest < Minitest::Test
 
   def test_used_routes_are_ignored
     assert_routed_actions 'admin/shops#index', 'api/books#index'
+  end
+
+  def test_overridden_routes_are_ignored
+    assert_equal({}, @traceroute.overridden_routes)
   end
 end
 
@@ -88,7 +95,7 @@ class EmptyFileTest < Minitest::Test
   end
 
   def test_empty_yaml_file_is_handled_the_same_as_no_file
-    assert_defined_action_methods 'users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'jasmine_rails/spec_runner#index'
+    assert_defined_action_methods 'users#index', 'users#show', 'users#index2', 'users#custom_action', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'jasmine_rails/spec_runner#index'
   end
 
   def test_property_with_no_key
@@ -127,7 +134,7 @@ class InvalidFileTest < Minitest::Test
   end
 
   def test_empty_yaml_file_is_handled_the_same_as_no_file
-    assert_defined_action_methods 'users#index', 'users#show', 'users#index2', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'jasmine_rails/spec_runner#index'
+    assert_defined_action_methods 'users#index', 'users#show', 'users#index2', 'users#custom_action', 'admin/shops#create', 'admin/shops#index', 'api/books#create', 'api/books#index', 'jasmine_rails/spec_runner#index'
   end
 
   def test_property_with_no_key


### PR DESCRIPTION
A new rule checks that there are no routes that override each other.
The overriding can be caused by an incorrect routes order in ```routes.rb```.

E.g.
```ruby
# config/routes.rb

# bad: 'import' keyword is considered as an invalid user id. 404 seems to be caused.
get "/users/:user_id/purchases", to: "purchases#index"
get "/users/import/purchases", to: "user_import_purchases#index"

# good: some 'import page' is rendered by some UserImportPurchasesController successfully
get "/users/import/purchases", to: "user_import_purchases#index"
get "/users/:user_id/purchases", to: "purchases#index"
```