### PR TITLE
Report unused ignore lines in config

### DIFF
--- a/lib/tasks/traceroute.rake
+++ b/lib/tasks/traceroute.rake
@@ -19,8 +19,24 @@ task :traceroute => :environment do
     unreachable_action_methods.each {|action| puts "  #{action}"}
   end
 
+  unused_action_checks = traceroute.unused_ignored_unreachable_action_methods
+  unless unused_action_checks.empty?
+    puts "Unused action method ignores present (#{unused_action_checks.count}):"
+    unused_action_checks.each {|action| puts "  #{action}"}
+  end
+
+  unused_route_checks = traceroute.unused_ignored_unused_routes
+  unless unused_route_checks.empty?
+    puts "Unused route ignores present (#{unused_route_checks.count}):"
+    unused_route_checks.each {|route| puts "  #{route}"}
+  end
+
   if ENV['FAIL_ON_ERROR'] && ((!ENV['UNREACHABLE_ACTION_METHODS_ONLY'] && unused_routes.any?) || (!ENV['UNUSED_ROUTES_ONLY'] && unreachable_action_methods.any?))
     fail "Unused routes or unreachable action methods detected."
+  end
+
+  if ENV['FAIL_ON_ERROR'] && (unused_action_checks.any? || unused_route_checks.any?)
+    fail "Unused routes or unreachable action ignore lines detected in config."
   end
 end
 

--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -16,9 +16,10 @@ class Traceroute
     @app = app
 
     @ignored_unreachable_actions = []
-    @ignored_unused_routes = [/^\/cable$/]
+    @ignored_unused_routes = default_unused_routes.dup
 
-    @ignored_unused_routes << %r{^#{@app.config.assets.prefix}} if @app.config.respond_to? :assets
+    @used_ignored_unreachable_actions = []
+    @used_ignored_unused_routes = []
 
     config_filename = %w(.traceroute.yaml .traceroute.yml .traceroute).detect {|f| File.exist?(f)}
     if config_filename && (config = YAML.load_file(config_filename))
@@ -50,6 +51,14 @@ class Traceroute
     defined_action_methods - routed_actions
   end
 
+  def unused_ignored_unused_routes
+    @ignored_unused_routes - @used_ignored_unused_routes - default_unused_routes
+  end
+
+  def unused_ignored_unreachable_action_methods
+    @ignored_unreachable_actions - @used_ignored_unreachable_actions
+  end
+
   def defined_action_methods
     @defined_action_methods ||= [ActionController::Base, (ActionController::API if defined?(ActionController::API))].compact.map do |klass|
       klass.descendants.map do |controller|
@@ -57,7 +66,7 @@ class Traceroute
           "#{controller.controller_path}##{action}"
         end
       end.flatten
-    end.flatten.reject {|r| @ignored_unreachable_actions.any? { |m| r.match(m) } }
+    end.compact.flatten.reject {|r| check_match_and_store_used(r, @ignored_unreachable_actions, @used_ignored_unreachable_actions) }
   end
 
   def routed_actions
@@ -71,7 +80,7 @@ class Traceroute
       else
         ((String === r.path) && r.path.to_s) || r.path.spec.to_s  # unknown routes
       end
-    end.compact.flatten.reject {|r| @ignored_unused_routes.any? { |m| r.match(m) } }
+    end.compact.flatten.reject { |r| check_match_and_store_used(r, @ignored_unused_routes, @used_ignored_unused_routes) }
   end
 
   def routes
@@ -95,5 +104,25 @@ class Traceroute
     routes.reject! {|r| r.app.is_a?(ActionDispatch::Routing::Redirect)}
 
     routes
+  end
+
+  private
+
+  def check_match_and_store_used(item, ignores, used)
+    ignores.any? { |m|
+      if item.match(m)
+        used << m
+        true
+      end
+    }
+  end
+
+  def default_unused_routes
+    @default_unused_routes ||=
+      begin
+        defaults = [/^\/cable$/]
+        defaults << %r{^#{@app.config.assets.prefix}} if @app.config.respond_to? :assets
+        defaults.freeze
+      end
   end
 end

--- a/test/yaml_test.rb
+++ b/test/yaml_test.rb
@@ -26,8 +26,10 @@ class DotFileTest < Minitest::Test
     File.open ".traceroute.yaml", "w" do |file|
       file.puts 'ignore_unreachable_actions:'
       file.puts '- ^jasmine_rails\/'
+      file.puts '- foo_unused'
       file.puts 'ignore_unused_routes:'
       file.puts '- ^users'
+      file.puts '- bar_unused'
     end
 
     DummyApp::Application.routes.draw do
@@ -57,6 +59,16 @@ class DotFileTest < Minitest::Test
 
   def test_used_routes_are_ignored
     assert_routed_actions 'admin/shops#index', 'api/books#index'
+  end
+
+  def test_unused_ignored_unused_routes_are_reported
+    @traceroute.routed_actions # Trigger the check
+    assert_equal @traceroute.unused_ignored_unused_routes, [/bar_unused/]
+  end
+
+  def test_unused_ignored_unreachable_action_methods_are_reported
+    @traceroute.defined_action_methods # Trigger the check
+    assert_equal @traceroute.unused_ignored_unreachable_action_methods, [/foo_unused/]
   end
 end
 


### PR DESCRIPTION
This change allows traceroute to report when there are unused lines in its config. ie, lines that never "match to ignore" anything.

Unused lines are not just a buildup of historic cruft, they could also unintentionally ignore matching code further down the line if the regex is left in, and then it matches something else entirely.

It will currently fire all the time - up to you if you want to hide it behind an ENV.