### PR TITLE
Ignore Option Redirects When Collecting Routes

### DIFF
--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -82,7 +82,7 @@ class Traceroute
 
   def collect_routes(routes)
     routes = routes.each_with_object([]) do |r, tmp_routes|
-      next if (ActionDispatch::Routing::Mapper::Constraints === r.app) && (%w[ActionDispatch::Routing::PathRedirect ActionDispatch::Routing::Redirect].include?(r.app.app.class.name))
+      next if (ActionDispatch::Routing::Mapper::Constraints === r.app) && (%w[ActionDispatch::Routing::PathRedirect ActionDispatch::Routing::OptionRedirect ActionDispatch::Routing::Redirect].include?(r.app.app.class.name))
 
       if r.app.is_a?(ActionDispatch::Routing::Mapper::Constraints) && r.app.app.respond_to?(:routes)
         engine_routes = r.app.app.routes

--- a/test/traceroute_with_engine_test.rb
+++ b/test/traceroute_with_engine_test.rb
@@ -66,6 +66,8 @@ module TracerouteWithEngineTest
     def setup
       TestEngine::Engine.routes.draw do
         resources :tasks, only: :index
+
+        root to: redirect(path: '/tasks')
       end
 
       Rails.application.routes_reloader.route_sets << DummyApp::Application.routes


### PR DESCRIPTION
Found this bug when upgrading the [good_job](https://github.com/bensheldon/good_job) gem which has an engine which uses redirects in its routes, more specifically, [redirects with named arguments.](https://github.com/bensheldon/good_job/blob/eebf63fd3bb614774c9801c978ebea617ca69f57/config/routes.rb#L3)

These also didn't appear under the `/good_job` path:
```
Unused routes (2):
  /
  /jobs/mass_update(.:format)
```

This PR updates the `collect_routes` method to ignore `ActionDispatch::Routing::OptionRedirect` routes, which are [created when using redirects with named arguments](https://github.com/rails/rails/blob/2cf8f37d50977006dda88cfc947bf28f03270c68/actionpack/lib/action_dispatch/routing/redirection.rb#L195)